### PR TITLE
Fixes ACPI and booter settings to correctly support multiboot

### DIFF
--- a/Docs/ACPI/SSDT-Battery.dsl
+++ b/Docs/ACPI/SSDT-Battery.dsl
@@ -205,7 +205,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XACW ())
+                Return (XACW ())
             }
         }
 
@@ -232,7 +232,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XBAW ())
+                Return (XBAW ())
             }
         }
 
@@ -286,7 +286,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XTIF ())
+                Return (XTIF (Arg0))
             }
         }
 
@@ -377,7 +377,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XTST ())
+                Return (XTST (Arg0, Arg1))
             }
         }
 
@@ -399,7 +399,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                \_SB.PCI0.LPCB.EC0.XTLB ()
+                XTLB ()
             }
         }
 
@@ -546,7 +546,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XBTI ())
+                Return (XBTI (Arg0))
             }
         }
 
@@ -641,7 +641,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XBTC ())
+                Return (XBTC ())
             }
         }
 
@@ -847,7 +847,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.SXTC ())
+                Return (SXTC (Arg0, Arg1, Arg2))
             }
         }
 
@@ -902,7 +902,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_SB.PCI0.LPCB.EC0.XTIX ())
+                Return (\_SB.PCI0.LPCB.EC0.XTIX (Arg0))
             }
         }
     }
@@ -925,7 +925,7 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
             Else
             {
-                Return (\_TZ.XXGC ())
+                Return (XXGC ())
             }
         }
     }
@@ -936,12 +936,10 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
         {
             Local0 = ^PCI0.LPCB.EC0.BTST (Arg0, One)
             If ((Local0 == Zero)){}
-            // Sleep on low battery(SOLB)
             SOLB (Arg0)
             Return (DerefOf (NBST [Arg0]))
         }
 
-        // This toggle key can be switched in SSDT-INIT.dsl.
         Name (SLBV, Zero)
         Method (MSGB, 0, NotSerialized)
         {
@@ -955,28 +953,22 @@ DefinitionBlock ("", "SSDT", 2, "what", "BATTERY", 0x00000000)
             }
         }
 
-        // SOLB
         Method (SOLB, 1, NotSerialized)
         {
             If (SLBV = One)
             {
-                // If discharging,
                 If ((DerefOf (DerefOf (NBST [Arg0]) [Zero]) & One
                     ))
                 {
-                    // store 20 % battery capacity into Local2
                     Divide (DerefOf (DerefOf (NBTE [Arg0]) [0x02]), 0x0A, Local0, 
                         Local1)
                     Local1 *= 0x02
-                    // If current capacity is less than 20 % battery capacity,
                     If ((DerefOf (DerefOf (NBST [Arg0]) [0x02]) < Local1))
                     {
-                        // sleep.
                         Notify (SLPB, 0x80) // Status Change
                     }
                 }
             }
-            // Don't do anything if SLBV is not set.
             Else
             {
             }

--- a/Docs/ACPI/SSDT-INIT.dsl
+++ b/Docs/ACPI/SSDT-INIT.dsl
@@ -17,7 +17,6 @@ DefinitionBlock ("", "SSDT", 2, "what", "INIT", 0x00001000)
     External (_SB_.SLBV, IntObj)
     External (HPTE, FieldUnitObj)
     External (OSDW, MethodObj)    // 0 Arguments
-    External (OSYS, FieldUnitObj)
     External (STAS, FieldUnitObj)
 
     Method (\_SB.PCI0._INI, 0, Serialized)  // _INI: Initialize
@@ -25,11 +24,6 @@ DefinitionBlock ("", "SSDT", 2, "what", "INIT", 0x00001000)
         XINI ()
         If (OSDW ())
         {
-            // Some ACPI code checks for operating system identification to enable or disable certain features such as touchscreen functionality.
-            // Wacom touchscreen is enabled on Windows 2015 (Windows 10), and so forcing Windows 2015 ID on macOS here will enable touchscreen used with the right kexts.
-            // More exploration is needed as there are other unknown code that checks for OS version such as Method GTOS.
-            // https://www.tonymacx86.com/threads/hp-zbook-video-mux-control.316221/
-            OSYS = 0x07DF
             // HPTE is used in HPET._STA for it to return false when set to zero to match MacBookPro14,1.
             HPTE = Zero
             // STAS is used in RTC._STA for it to return true when set to one to force enable legacy RTC.

--- a/Docs/ACPI/SSDT-PS2.dsl
+++ b/Docs/ACPI/SSDT-PS2.dsl
@@ -20,8 +20,8 @@ DefinitionBlock ("", "SSDT", 2, "what", "PS2", 0x00000000)
                 If (RMTB)
                 {
                     Debug = "PS2:RMTB is set, enabling 2 & 3"
-                    Debug = "PS2:3.ADB 3d to PS2 6b:F3 to F14, brightness down"
-                    Debug = "PS2:4.ADB 3e to PS2 71:F4 to F15, brightness up"
+                    Debug = "PS2:2.ADB 3d to PS2 6b:F3 to F14, brightness down"
+                    Debug = "PS2:3.ADB 3e to PS2 71:F4 to F15, brightness up"
                 }
                 Else
                 {

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -661,6 +661,36 @@
 				<key>BaseSkip</key>
 				<integer>0</integer>
 				<key>Comment</key>
+				<string>TPL0: If ((OSYS &lt; 0x07DC)) to 0x0000 in \_SB.PCI0.I2C0.TPL0._INI to force initialization in macOS</string>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>lU9TWVML3Ac=</data>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>OemTableId</key>
+				<data></data>
+				<key>Replace</key>
+				<data>lU9TWVMLAAA=</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>5</integer>
+				<key>TableLength</key>
+				<integer>0</integer>
+				<key>TableSignature</key>
+				<data></data>
+			</dict>
+			<dict>
+				<key>Base</key>
+				<string></string>
+				<key>BaseSkip</key>
+				<integer>0</integer>
+				<key>Comment</key>
 				<string>TB3: M(_INI) to XINI in RP01</string>
 				<key>Count</key>
 				<integer>1</integer>
@@ -1494,7 +1524,7 @@
 			<key>4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102</key>
 			<dict>
 				<key>rtc-blacklist</key>
-				<data>WFmwsbKzt98=</data>
+				<data></data>
 				<key>revpatch</key>
 				<string>none</string>
 			</dict>
@@ -1503,7 +1533,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>msgbuf=10485760 -rtcfxdbg rtcfx_exclude=58,59,B0-B3,B7,DF acpi_layer=0x8 acpi_level=0x2 debug=0x100 keepsyms=1</string>
+				<string>msgbuf=10485760 -rtcfxdbg rtcfx_exclude=58,59,7F-83,B0-B3,B7,DE,DF acpi_layer=0x8 acpi_level=0x2 debug=0x100 keepsyms=1</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -779,7 +779,7 @@
 			<key>SignalAppleOS</key>
 			<false/>
 			<key>SyncRuntimePermissions</key>
-			<false/>
+			<true/>
 		</dict>
 	</dict>
 	<key>DeviceProperties</key>

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The conflicting RTC regions are at least `58, 59, 7F-83, B0-B3, B7, DE, DF`. By 
 If USB-C is enabled, wake results in a kernel panic. The current workaround is to enable Thunderbolt related patches. See [SSDT-TbtOnPch.dsl](/Docs/ACPI/SSDT-TbtOnPch.dsl).
 
 ### Sleep on low battery
-The batteries on modern portable devices may wear down quickly if the battery level is below a certain point. I have set the limit on battery level at which the laptop goes to sleep. See the applied SSDT--[SSDT-BAT.dsl](/Docs/ACPI/SSDT-BAT.dsl)--and background reading on how to implement such patch--[Battery: Hibernate at low battery level](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/Docs/Battery/hibernate-at-low-battery-level.md).
+The batteries on modern portable devices may wear down quickly if the battery level is below a certain point. I have set the limit on battery level at which the laptop goes to sleep. See the applied SSDT--[SSDT-Battery.dsl](/Docs/ACPI/SSDT-Battery.dsl)--and background reading on how to implement such patch--[Battery: Hibernate at low battery level](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/Docs/Battery/hibernate-at-low-battery-level.md).
 
 ### Modern Standby
 Modern Standby, or Windows Sleep, is not supported on macOS. It needs to be disabled for actual sleep and wake.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Windows 10 ALPS keyboard driver writes _something_ to the firmware which breaks 
 ### Sleep, wake, and hibernation
 The Real-Time Clock (RTC) Power Loss (005) error is displayed on HP machines if RTC regions unsupported by the machine are written. This may happen on restart or resume from hibernation.
 
-The conflicting RTC regions are at least `58, 59, B0-B3, B7, DF`. By "at least," I mean it works for regular sleep and wake, but not for resume from hibernation, upon which the very RTC error is displayed.
+The conflicting RTC regions are at least `58, 59, 7F-83, B0-B3, B7, DE, DF`. By "at least," I mean it works for regular sleep and wake, but not for resume from hibernation, upon which the very RTC error is displayed.
 
 If USB-C is enabled, wake results in a kernel panic. The current workaround is to enable Thunderbolt related patches. See [SSDT-TbtOnPch.dsl](/Docs/ACPI/SSDT-TbtOnPch.dsl).
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ In progress
 - [x] DP-Alt mode to output to secondary screen.
   - [x] ~~It sometimes fails to output after wake which works again if unplugged and reconnected.~~ Progress in Thunderbolt 3 may have improved interaction with the graphics; The screen output is always recognized.
   - [ ] With or without the Thunderbolt work, sound output to secondary monitor is not always recognized. It seems it is recognized only if the laptop enters clamshell mode after which the sound works whether the laptop stays or exits the aforementioned mode thereafter. This may require AppleALC rewrite which I have no knowledge of.
+    - midi1996 says sound output always works, so it may be the USB-C hub that is problematic.
+    - AudioDxe.efi kills sound output no matter what.
 - [ ] Hibernation: Hibernation works, but is accompanied by the RTC power loss (005) error. See [Sleep
 , wake, and hibernation](#sleep-wake-and-hibernation).
 - [ ] Sleep and wake: See [Sleep, wake, and hibernation](#sleep-wake-and-hibernation).
@@ -67,7 +69,7 @@ In progress
 - [ ] Light sensor
 
 ### Not tested
-- WWAN slot. One stock antenna.
+- [ ] WWAN slot. One stock antenna.
 
 ## Installation
 


### PR DESCRIPTION
Fixes #19 
Additionally reduce OS recognition patch to one ACPI patch instance. It was needed only for touchscreen in macOS. Spoofing OS only for initialization forces the touchscreen in the right state.